### PR TITLE
Fix: Correct authentication check in password change handler (fixes #36)

### DIFF
--- a/lib/LocalAuthModule.js
+++ b/lib/LocalAuthModule.js
@@ -184,8 +184,8 @@ class LocalAuthModule extends AbstractAuthModule {
     const text = this.app.lang.translate(undefined, 'app.updateusertext')
     const html = this.app.lang.translate(undefined, 'app.updateuserhtml')
     try {
-      if(mailer.isEnabled) await mailer.send({ to: user.email, subject, text, html })
-    } catch(e) {
+      if (mailer.isEnabled) await mailer.send({ to: user.email, subject, text, html })
+    } catch (e) {
       this.log('error', e)
     }
 
@@ -284,13 +284,13 @@ class LocalAuthModule extends AbstractAuthModule {
   async changePasswordHandler (req, res, next) {
     let email
     try {
-      if (req.auth.token) { // already authenticated, so can use auth data
+      if (req.auth.token && req.body.noAuth !== 'true') { // already authenticated, so can use auth data
         if (req.auth.token.type !== this.type) throw new Error()
         // allow for a specific email to be passed via body, falling back to the email from the auth data
         email = req.body.email || req.auth.user.email
         // validate the existing password for security
-        const [user] = await this.users.find({ email });
-        await PasswordUtils.compare(req.body.oldPassword, user.password);
+        const [user] = await this.users.find({ email })
+        await PasswordUtils.compare(req.body.oldPassword, user.password)
       } else { // no authenticated, so should expect body data
         const tokenData = await PasswordUtils.validateReset(req.body.token)
         email = tokenData.email


### PR DESCRIPTION
Closes #36

### Fix
* Corrected spacing around `if` and `catch` statements to conform to StandardJS style
* Removed unnecessary semicolons from lines 291-292

### Update
* Added `noAuth` body parameter check to allow bypassing password validation when using the reset password page

### Testing
1. Test password change with authenticated user (normal flow)
2. Test password change with `noAuth: 'true'` in request body to verify bypass works for reset password page
3. Test password reset flow using token (unauthenticated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)