### PR TITLE
Update: Remove unnecessary await from synchronous schema.validate calls

### DIFF
--- a/lib/PasswordUtils.js
+++ b/lib/PasswordUtils.js
@@ -53,7 +53,7 @@ class PasswordUtils {
     }
     const jsonschema = await App.instance.waitForModule('jsonschema')
     const schema = await jsonschema.getSchema('localpassword')
-    await schema.validate({ password: plainPassword })
+    schema.validate({ password: plainPassword })
 
     const saltRounds = await PasswordUtils.getConfig('saltRounds')
     const salt = await promisify(bcrypt.genSalt)(saltRounds)

--- a/tests/LocalAuthModule.spec.js
+++ b/tests/LocalAuthModule.spec.js
@@ -91,7 +91,7 @@ const mockMongodb = {
 
 const mockJsonschema = {
   getSchema: async () => ({
-    validate: async () => true
+    validate: () => true
   })
 }
 

--- a/tests/PasswordUtils.spec.js
+++ b/tests/PasswordUtils.spec.js
@@ -43,7 +43,7 @@ const mockAuthlocal = {
 
 const mockJsonschema = {
   getSchema: async () => ({
-    validate: async () => true
+    validate: () => true
   })
 }
 


### PR DESCRIPTION
### Fixes adapt-security/adapt-authoring-jsonschema#58

### Update
* Remove `await` from `schema.validate()` in `PasswordUtils.generate()` — now synchronous in adapt-schemas v3
* Update test mocks to reflect synchronous `validate` signature

### Testing
1. Run `npm test`
2. Verify password validation still works

Depends on https://github.com/adapt-security/adapt-authoring-jsonschema/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)