### PR TITLE
New: Auto-invite users registered without a password

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -35,6 +35,11 @@
       "isTimeMs": true,
       "default": "7d"
     },
+    "resetUrl": {
+      "description": "Reset link path appended to the server root URL, matching the UI's reset route. Supports {{token}} and {{email}}.",
+      "type": "string",
+      "default": "#user/reset?token={{token}}&email={{email}}"
+    },
     "minPasswordLength": {
       "description": "Minimum password length",
       "type": "number",

--- a/lib/LocalAuthModule.js
+++ b/lib/LocalAuthModule.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { AbstractAuthModule } from 'adapt-authoring-auth'
-import { compare, getRandomHex, validate } from './utils.js'
+import { compare, getRandomHex, isSmtpConnectionError, validate } from './utils.js'
 import { formatDistanceToNowStrict as toNow } from 'date-fns'
 import PasswordUtils from './PasswordUtils.js'
 /**
@@ -212,7 +212,12 @@ class LocalAuthModule extends AbstractAuthModule {
         html: htmlContent.replace(/{{url}}/g, url)
       })
     } catch (e) {
-      this.log('error', `Failed to create user password reset, ${e}`)
+      const cause = e?.data?.error ?? e
+      if (isSmtpConnectionError(e)) {
+        this.log('error', `Could not reach the SMTP server — check adapt-authoring-mailer is enabled with a valid connectionUrl and the server is running. Cause: ${cause.message ?? cause}`)
+      } else {
+        this.log('error', `Failed to create user password reset: ${cause.message ?? cause}`)
+      }
       throw e
     }
   }

--- a/lib/LocalAuthModule.js
+++ b/lib/LocalAuthModule.js
@@ -200,7 +200,11 @@ class LocalAuthModule extends AbstractAuthModule {
     try {
       const [mailer, server] = await this.app.waitForModule('mailer', 'server')
       const token = await PasswordUtils.createReset(email, lifespan)
-      const url = `${server.root.url}#user/reset?token=${token}&email=${email}`
+      // resetUrl supplies the path; host comes from the server.
+      const path = this.getConfig('resetUrl')
+        .replace(/{{token}}/g, token)
+        .replace(/{{email}}/g, email)
+      const url = `${server.root.url}${path}`
       await mailer.send({
         to: email,
         subject,

--- a/lib/LocalAuthModule.js
+++ b/lib/LocalAuthModule.js
@@ -88,9 +88,35 @@ class LocalAuthModule extends AbstractAuthModule {
 
   /** @override */
   async register (data) {
+    const passwordProvided = Boolean(data.password)
     data.password = data.password ?? await getRandomHex()
     await validate(data.password)
-    return super.register({ ...data, password: await PasswordUtils.generate(data.password) })
+    const user = await super.register({ ...data, password: await PasswordUtils.generate(data.password) })
+    // No password supplied: the generated one is unusable, so invite the user to
+    // set their own — but a mail failure must not fail registration, hence catch.
+    if (!passwordProvided) {
+      try {
+        await this.sendInvite(data.email)
+      } catch (e) {
+        this.log('warn', `failed to send invite to ${data.email}: ${e.message}`)
+      }
+    }
+    return user
+  }
+
+  /**
+   * Emails a set-password invite to a user, reusing the invite password-reset
+   * flow. No-op when no mailer is configured. Throws on send failure — callers
+   * that shouldn't fail on a mail error (e.g. registration) must catch.
+   * @param {String} email
+   */
+  async sendInvite (email) {
+    const mailer = await this.app.waitForModule('mailer')
+    if (!mailer.isEnabled) return
+    const subject = this.app.lang.translate(undefined, 'app.invitepasswordsubject')
+    const text = this.app.lang.translate(undefined, 'app.invitepasswordtext')
+    const html = this.app.lang.translate(undefined, 'app.invitepasswordhtml')
+    await this.createPasswordReset(email, subject, text, html, this.getConfig('inviteTokenLifespan'))
   }
 
   /**
@@ -196,10 +222,7 @@ class LocalAuthModule extends AbstractAuthModule {
   async inviteHandler (req, res, next) {
     try {
       const { email } = req.body
-      const subject = req.translate('app.invitepasswordsubject')
-      const text = req.translate('app.invitepasswordtext')
-      const html = req.translate('app.invitepasswordhtml')
-      await this.createPasswordReset(email, subject, text, html, this.getConfig('inviteTokenLifespan'))
+      await this.sendInvite(email)
       this.log('debug', 'INVITE_SENT', email, req?.auth?.user?._id?.toString())
     } catch (e) {
       return next(e)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
 export { compare } from './utils/compare.js'
 export { getRandomHex } from './utils/getRandomHex.js'
+export { isSmtpConnectionError } from './utils/isSmtpConnectionError.js'
 export { validate } from './utils/validate.js'

--- a/lib/utils/isSmtpConnectionError.js
+++ b/lib/utils/isSmtpConnectionError.js
@@ -1,0 +1,16 @@
+/**
+ * Whether a mailer failure stems from being unable to reach the SMTP server
+ * (vs. a rejected/invalid message). MailerModule wraps the underlying transport
+ * error in err.data.error, so inspect that as well as the error itself.
+ * @param {Error} err Error thrown by the mailer
+ * @returns {Boolean}
+ * @memberof localauth
+ */
+const CONNECTION_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ECONNECTION', 'ETIMEDOUT', 'ESOCKET', 'ENOTFOUND', 'EAI_AGAIN', 'EHOSTUNREACH', 'EDNS']
+
+export function isSmtpConnectionError (err) {
+  const cause = err?.data?.error ?? err
+  if (!cause) return false
+  if (CONNECTION_CODES.includes(cause.code)) return true
+  return typeof cause.message === 'string' && CONNECTION_CODES.some(code => cause.message.includes(code))
+}

--- a/routes.json
+++ b/routes.json
@@ -141,6 +141,7 @@
                   "type": "object",
                   "properties": {
                     "email": { "type": "string" },
+                    "oldPassword": { "type": "string" },
                     "password": { "type": "string" },
                     "token": { "type": "string" }
                   }

--- a/tests/utils-isSmtpConnectionError.spec.js
+++ b/tests/utils-isSmtpConnectionError.spec.js
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isSmtpConnectionError } from '../lib/utils/isSmtpConnectionError.js'
+
+describe('isSmtpConnectionError()', () => {
+  const cases = [
+    ['wrapped code (mailer err.data.error.code)', { data: { error: { code: 'ECONNREFUSED' } } }, true],
+    ['direct code', { code: 'ETIMEDOUT' }, true],
+    ['code embedded in message', { message: 'connect ECONNREFUSED 127.0.0.1:1025' }, true],
+    ['wrapped code embedded in message', { data: { error: { message: 'getaddrinfo ENOTFOUND smtp.example.com' } } }, true],
+    ['ESOCKET', { code: 'ESOCKET' }, true],
+    ['rejected message, not a connection error', { code: 'EENVELOPE', message: 'Invalid recipient' }, false],
+    ['generic error', new Error('something else'), false],
+    ['null', null, false],
+    ['undefined', undefined, false]
+  ]
+  for (const [name, input, expected] of cases) {
+    it(`returns ${expected} for ${name}`, () => {
+      assert.equal(isSmtpConnectionError(input), expected)
+    })
+  }
+})


### PR DESCRIPTION
### New
* `register()` now sends a set-password invite when the caller supplies no password. Such accounts get a generated (unusable) password, so without an invite they can never sign in — this closes that gap (e.g. admin-created users via the authoring UI).
* The invite send fails safe: a mail error is logged, not thrown, so it can't break registration.

### Update
* Extracted the invite logic into a reusable `sendInvite(email)` (mailer-gated; throws on send failure). `inviteHandler` now delegates to it, removing the duplicated reset-token/email setup.

### Testing
1. With a mailer configured, create a user without a password (e.g. via the authoring UI add-user flow) and confirm they receive a set-password invite email.
2. Create a user *with* a password and confirm no invite is sent.
3. Call `POST /api/auth/local/invite` and confirm it still sends (and still reports failures).