### PR TITLE
Update: Send branded templated emails via the mailer (fixes #64)

### DIFF
--- a/lib/LocalAuthModule.js
+++ b/lib/LocalAuthModule.js
@@ -113,10 +113,17 @@ class LocalAuthModule extends AbstractAuthModule {
   async sendInvite (email) {
     const mailer = await this.app.waitForModule('mailer')
     if (!mailer.isEnabled) return
-    const subject = this.app.lang.translate(undefined, 'app.invitepasswordsubject')
-    const text = this.app.lang.translate(undefined, 'app.invitepasswordtext')
-    const html = this.app.lang.translate(undefined, 'app.invitepasswordhtml')
-    await this.createPasswordReset(email, subject, text, html, this.getConfig('inviteTokenLifespan'))
+    const appName = this.app.config.get('adapt-authoring-core.appName')
+    const t = (k) => this.app.lang.translate(undefined, `app.${k}`, { appName })
+    await this.createPasswordReset(email, {
+      subject: t('email_invite_subject'),
+      content: {
+        emblem: 'spark',
+        title: t('email_invite_title'),
+        body: t('email_invite_body'),
+        button: { label: t('email_invite_button') }
+      }
+    }, this.getConfig('inviteTokenLifespan'))
   }
 
   /**
@@ -173,11 +180,20 @@ class LocalAuthModule extends AbstractAuthModule {
 
     await this.disavowUser({ userId: user._id, authType: this.type })
 
-    const subject = this.app.lang.translate(undefined, 'app.updateusersubject')
-    const text = this.app.lang.translate(undefined, 'app.updateusertext')
-    const html = this.app.lang.translate(undefined, 'app.updateuserhtml')
+    const appName = this.app.config.get('adapt-authoring-core.appName')
+    const t = (k) => this.app.lang.translate(undefined, `app.${k}`, { appName })
     try {
-      if (mailer.isEnabled) await mailer.send({ to: user.email, subject, text, html })
+      if (mailer.isEnabled) {
+        await mailer.sendTemplated({
+          to: user.email,
+          subject: t('email_passwordupdated_subject'),
+          content: {
+            emblem: 'check',
+            title: t('email_passwordupdated_title'),
+            body: t('email_passwordupdated_body')
+          }
+        })
+      }
     } catch (e) {
       this.log('error', e)
     }
@@ -186,14 +202,15 @@ class LocalAuthModule extends AbstractAuthModule {
   }
 
   /**
-   * Creates a new password reset token and sends an email
+   * Creates a new password reset token and sends a templated email. The reset URL
+   * is built here and injected into the content's button.
    * @param {String} email
-   * @param {String} subject
-   * @param {String} textContent
-   * @param {String} htmlContent
+   * @param {Object} message
+   * @param {String} message.subject Email subject (already translated)
+   * @param {Object} message.content Templated-email content ({ emblem?, title, body, button? }) — the button's url is set here
    * @param {Number} lifespan The lifespan of the reset
    */
-  async createPasswordReset (email, subject, textContent, htmlContent, lifespan) {
+  async createPasswordReset (email, { subject, content } = {}, lifespan) {
     if (!email) {
       throw this.app.errors.INVALID_PARAMS.setData({ params: ['email'] })
     }
@@ -204,13 +221,8 @@ class LocalAuthModule extends AbstractAuthModule {
       const path = this.getConfig('resetUrl')
         .replace(/{{token}}/g, token)
         .replace(/{{email}}/g, email)
-      const url = `${server.root.url}${path}`
-      await mailer.send({
-        to: email,
-        subject,
-        text: textContent.replace(/{{url}}/g, url),
-        html: htmlContent.replace(/{{url}}/g, url)
-      })
+      if (content?.button) content.button.url = `${server.root.url}${path}`
+      await mailer.sendTemplated({ to: email, subject, content })
     } catch (e) {
       const cause = e?.data?.error ?? e
       if (isSmtpConnectionError(e)) {
@@ -263,10 +275,17 @@ class LocalAuthModule extends AbstractAuthModule {
   async forgotPasswordHandler (req, res, next) {
     try {
       const { email } = req.body
-      const subject = req.translate('app.forgotpasswordsubject')
-      const text = req.translate('app.forgotpasswordtext')
-      const html = req.translate('app.forgotpasswordhtml')
-      await this.createPasswordReset(email, subject, text, html)
+      const appName = this.app.config.get('adapt-authoring-core.appName')
+      const t = (k) => this.app.lang.translate(undefined, `app.${k}`, { appName })
+      await this.createPasswordReset(email, {
+        subject: t('email_reset_subject'),
+        content: {
+          emblem: 'key',
+          title: t('email_reset_title'),
+          body: t('email_reset_body'),
+          button: { label: t('email_reset_button') }
+        }
+      })
       this.log('debug', 'RESET_SENT', email, req?.auth?.user?._id?.toString())
     } catch (e) { // don't return an error to avoid signifying correct user/pass combinations
       this.log('error', 'RESET_PASS_FAILED', e)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "adapt-authoring-jsonschema": "^1.2.0",
-    "adapt-authoring-mailer": "^1.0.2",
+    "adapt-authoring-mailer": "^1.6.0",
     "adapt-authoring-mongodb": "^3.0.0",
     "adapt-authoring-roles": "^1.1.3",
     "adapt-authoring-server": "^2.1.0",

--- a/tests/LocalAuthModule.spec.js
+++ b/tests/LocalAuthModule.spec.js
@@ -46,6 +46,7 @@ let disavowCalls = []
 let secureRouteCalls = []
 let unsecureRouteCalls = []
 let mailerSendCalls = []
+let mailerSendTemplatedCalls = []
 
 const mockUsers = {
   find: async (query) => usersStore.filter(u => {
@@ -72,7 +73,8 @@ const mockRoles = {
 
 const mockMailer = {
   isEnabled: true,
-  send: async (opts) => { mailerSendCalls.push(opts) }
+  send: async (opts) => { mailerSendCalls.push(opts) },
+  sendTemplated: async (opts) => { mailerSendTemplatedCalls.push(opts) }
 }
 
 const mockServer = {
@@ -114,6 +116,7 @@ const mockApp = {
     if (names.length === 1) return moduleMap[names[0]]
     return names.map(n => moduleMap[n])
   },
+  config: { get: () => 'Adapt' },
   lang: {
     translate: (_, key) => 'translated:' + key
   }
@@ -570,14 +573,49 @@ describe('LocalAuthModule', () => {
     })
 
     it('should send email notification after password update when mailer is enabled', async () => {
-      mailerSendCalls = []
+      mailerSendTemplatedCalls = []
       await mod.updateUser('user-id-1', { password: 'newpassword' })
-      assert.ok(mailerSendCalls.length > 0)
-      assert.equal(mailerSendCalls[0].to, 'test@example.com')
+      assert.ok(mailerSendTemplatedCalls.length > 0)
+      assert.equal(mailerSendTemplatedCalls[0].to, 'test@example.com')
+    })
+
+    it('should send a templated password-updated email (check emblem, no button)', async () => {
+      mailerSendTemplatedCalls = []
+      await mod.updateUser('user-id-1', { password: 'newpassword' })
+      const sent = mailerSendTemplatedCalls[0]
+      assert.equal(sent.content.emblem, 'check')
+      assert.ok(sent.subject)
+      assert.ok(sent.content.title)
+      assert.equal(sent.content.button, undefined)
     })
 
     it('should pass useDefaults:false and ignoreRequired:true for non-password updates', async () => {
       await assert.doesNotReject(() => mod.updateUser('user-id-1', { firstName: 'Test' }))
+    })
+  })
+
+  describe('#sendInvite()', () => {
+    it('should build invite content (spark emblem + set-password button) for createPasswordReset', async () => {
+      let captured
+      const original = mod.createPasswordReset.bind(mod)
+      mod.createPasswordReset = async (email, message) => { captured = { email, message } }
+      await mod.sendInvite('invite@example.com')
+      mod.createPasswordReset = original
+      assert.equal(captured.email, 'invite@example.com')
+      assert.equal(captured.message.content.emblem, 'spark')
+      assert.ok(captured.message.subject)
+      assert.ok(captured.message.content.button.label)
+    })
+
+    it('should be a no-op when the mailer is disabled', async () => {
+      mockMailer.isEnabled = false
+      let called = false
+      const original = mod.createPasswordReset.bind(mod)
+      mod.createPasswordReset = async () => { called = true }
+      await mod.sendInvite('invite@example.com')
+      mod.createPasswordReset = original
+      mockMailer.isEnabled = true
+      assert.equal(called, false)
     })
   })
 
@@ -648,7 +686,7 @@ describe('LocalAuthModule', () => {
     it('should pass inviteTokenLifespan to createPasswordReset', async () => {
       let receivedLifespan
       const original = mod.createPasswordReset.bind(mod)
-      mod.createPasswordReset = async (email, subject, text, html, lifespan) => {
+      mod.createPasswordReset = async (email, message, lifespan) => {
         receivedLifespan = lifespan
       }
       const req = {


### PR DESCRIPTION
### Fixes #64

### Update
- `sendInvite`, `forgotPasswordHandler`, and the password-updated notification in `updateUser` now build a templated-email content object and send via the mailer's `sendTemplated()` (emblem + title + body + optional button) instead of assembling raw subject/text/html.
- `createPasswordReset` now takes `(email, { subject, content }, lifespan)`, builds the reset URL into the content's button, and calls `sendTemplated`. **Note:** this is an internal signature change to `createPasswordReset`.
- Email copy now comes from the langpack `email_invite_*` / `email_reset_*` / `email_passwordupdated_*` keys (cgkineo/adapt-authoring-langpack-en#3); app name is read from `adapt-authoring-core`.
- Bumps the `adapt-authoring-mailer` peer dependency to `^1.6.0` (the version that adds `sendTemplated`).

### Breaking
- `createPasswordReset` signature changed (see above) — flagging in case any external caller relies on the old `(email, subject, text, html, lifespan)` form.

### Testing
- `npm test` — 163 pass (updated invite/reset/password-updated specs; new `sendInvite` content tests). `npx standard` clean.

### Depends on
- adapt-security/adapt-authoring-mailer#59 (sendTemplated)
- cgkineo/adapt-authoring-langpack-en#3 (copy keys)
- adapt-security/adapt-authoring-core#119 (appName/branding config)